### PR TITLE
doc: ajouter directives bug tracker pour chaque fonctionnalité

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Instructions pour les agents
+
+- Tenir un fichier de suivi des bugs distinct pour chaque fonctionnalité.
+- Pour chaque bug, noter ce qui ne fonctionnait pas et les modifications apportées.
+- Avant d'essayer de corriger un bug, consulter le fichier de suivi correspondant.
+  Cela permet de ne pas répéter les mêmes approches.


### PR DESCRIPTION
## Summary
- documenter l'obligation de tenir un fichier de suivi des bugs pour chaque fonctionnalité
- préciser qu'il faut noter ce qui ne fonctionnait pas, les modifications, et consulter ce suivi avant toute nouvelle tentative

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aee8fffcec8320983966af20d32490