### PR TITLE
Refactor planning layout for flexible segments

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -5,8 +5,8 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 ## Fonctionnement général
 - **Création de projet** : l'utilisateur génère un code unique permettant d'identifier un planning.
 - **Chargement de projet** : le code permet de recharger un planning précédemment sauvegardé.
-- **Planification** : pour chaque jour, les horaires du matin et de l'après-midi peuvent être saisis, en attribuant un pharmacien (A ou B) à chaque plage horaire.
-- **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien sur l'ensemble des deux semaines et désactive l'enregistrement si l'un d'eux dépasse 70 heures.
+- **Planification** : pour chaque jour de la semaine, l'utilisateur peut ajouter autant de tranches d'ouverture qu'il le souhaite. Pour chaque tranche, un pharmacien est attribué pour la semaine 1 et la semaine 2.
+- **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien pour chaque semaine et affiche également le total sur deux semaines. L'enregistrement est désactivé si un pharmacien dépasse 70 heures.
 - **Sauvegarde** : les données sont enregistrées côté serveur dans un fichier `.save` nommé d'après le code du projet.
 - **Nettoyage** : à chaque chargement de la page, les fichiers `.save` plus anciens que 15 jours sont automatiquement supprimés.
 

--- a/script.js
+++ b/script.js
@@ -1,21 +1,67 @@
+function addSegment(day, data={}) {
+    const container = document.querySelector(`.segments[data-day="${day}"]`);
+    if (!container) return;
+    const index = container.querySelectorAll('.segment').length;
+    const seg = document.createElement('div');
+    seg.className = 'segment';
+    seg.innerHTML = `
+        <input type="time" name="schedule[${day}][${index}][start]" value="${data.start||''}">
+        <input type="time" name="schedule[${day}][${index}][end]" value="${data.end||''}">
+        <select name="schedule[${day}][${index}][ph1]">
+            <option value="A" ${data.ph1==='B'?'':'selected'}>A S1</option>
+            <option value="B" ${data.ph1==='B'?'selected':''}>B S1</option>
+        </select>
+        <select name="schedule[${day}][${index}][ph2]">
+            <option value="A" ${data.ph2==='B'?'':'selected'}>A S2</option>
+            <option value="B" ${data.ph2==='B'?'selected':''}>B S2</option>
+        </select>
+        <button type="button" class="remove-segment">&times;</button>
+    `;
+    container.appendChild(seg);
+    seg.querySelectorAll('input, select').forEach(el => el.addEventListener('change', calculateHours));
+    seg.querySelector('.remove-segment').addEventListener('click', () => {
+        seg.remove();
+        renumberSegments(day);
+        calculateHours();
+    });
+    calculateHours();
+}
+
+function renumberSegments(day){
+    const container = document.querySelector(`.segments[data-day="${day}"]`);
+    container.querySelectorAll('.segment').forEach((seg,i)=>{
+        seg.querySelectorAll('input, select').forEach(el=>{
+            if(el.name.includes('[start]')) el.name = `schedule[${day}][${i}][start]`;
+            if(el.name.includes('[end]')) el.name = `schedule[${day}][${i}][end]`;
+            if(el.name.includes('[ph1]')) el.name = `schedule[${day}][${i}][ph1]`;
+            if(el.name.includes('[ph2]')) el.name = `schedule[${day}][${i}][ph2]`;
+        });
+    });
+}
+
 function calculateHours(){
-    let totalA=0, totalB=0;
-    document.querySelectorAll('tbody tr').forEach(row=>{
-        row.querySelectorAll('td.slot').forEach(slot=>{
-            const inputs = slot.querySelectorAll('input');
-            const sel = slot.querySelector('select');
-            const start = inputs[0].value;
-            const end = inputs[1].value;
+    const totals = {A:{w1:0,w2:0}, B:{w1:0,w2:0}};
+    document.querySelectorAll('.segments').forEach(dayContainer=>{
+        dayContainer.querySelectorAll('.segment').forEach(seg=>{
+            const start = seg.querySelector('input[name$="[start]"]').value;
+            const end = seg.querySelector('input[name$="[end]"]').value;
             if(start && end){
                 const diff = (new Date('1970-01-01T'+end) - new Date('1970-01-01T'+start))/3600000;
-                if(sel.value==='A') totalA += diff; else totalB += diff;
+                const ph1 = seg.querySelector('select[name$="[ph1]"]').value;
+                const ph2 = seg.querySelector('select[name$="[ph2]"]').value;
+                totals[ph1].w1 += diff;
+                totals[ph2].w2 += diff;
             }
         });
     });
-    document.getElementById('totalA').textContent = totalA;
-    document.getElementById('totalB').textContent = totalB;
+    document.getElementById('w1A').textContent = totals.A.w1;
+    document.getElementById('w1B').textContent = totals.B.w1;
+    document.getElementById('w2A').textContent = totals.A.w2;
+    document.getElementById('w2B').textContent = totals.B.w2;
+    document.getElementById('totA').textContent = totals.A.w1 + totals.A.w2;
+    document.getElementById('totB').textContent = totals.B.w1 + totals.B.w2;
     const saveBtn=document.getElementById('saveBtn');
-    if(totalA>70 || totalB>70){
+    if(totals.A.w1 + totals.A.w2 > 70 || totals.B.w1 + totals.B.w2 > 70){
         saveBtn.disabled=true;
         saveBtn.title='Un pharmacien dépasse 70h sur deux semaines';
     } else {
@@ -25,8 +71,17 @@ function calculateHours(){
 }
 
 if(document.getElementById('scheduleForm')){
-    calculateHours();
-    document.querySelectorAll('input[type="time"], select').forEach(el=>{
-        el.addEventListener('change', calculateHours);
+    document.querySelectorAll('.add-segment').forEach(btn=>{
+        btn.addEventListener('click',()=>addSegment(btn.dataset.day));
     });
+    document.querySelectorAll('.segment').forEach(seg=>{
+        seg.querySelectorAll('input, select').forEach(el=>el.addEventListener('change', calculateHours));
+        seg.querySelector('.remove-segment').addEventListener('click',()=>{
+            const day = seg.closest('.segments').dataset.day;
+            seg.remove();
+            renumberSegments(day);
+            calculateHours();
+        });
+    });
+    calculateHours();
 }

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ body {
     color: #1d1d1f;
 }
 .container {
-    max-width: 900px;
+    max-width: 1100px;
     margin: auto;
     padding: 20px;
 }
@@ -47,21 +47,29 @@ th, td {
     padding: 8px;
     text-align: center;
 }
-.slot {
+.columns {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 20px;
+}
+.planner, .summary {flex:1;}
+.segments .segment {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 6px;
 }
 input[type="time"], select {
     padding: 6px;
     border: 1px solid #ccc;
     border-radius: 6px;
 }
+.add-segment {padding:6px 10px;}
+.summary table {width:100%; border-collapse: collapse;}
+.summary th, .summary td {border-bottom:1px solid #ccc; padding:8px; text-align:center;}
 .message {color: green;}
 .error {color: red;}
 .code-info {text-align: center; margin-top: 20px;}
-.totals {display: flex; justify-content: center; gap: 20px; margin-top: 10px;}
-@media (min-width:600px){
-    .slot {flex-direction: row; justify-content: center;}
-    .slot input, .slot select {flex:1;}
+@media (min-width:800px){
+    .columns {flex-direction: row; align-items:flex-start;}
 }


### PR DESCRIPTION
## Summary
- refactor schedule UI into planner and recap columns
- allow custom opening segments per day with separate week 1 and week 2 assignments
- compute weekly and total pharmacist hours dynamically

## Testing
- `php -l index.php`
- `node --check script.js && echo 'Script OK'`

------
https://chatgpt.com/codex/tasks/task_e_68aeeb38ae1c8320ac1178f5d5caf372