### PR TITLE
Ajout d'un compteur hebdomadaire d'heures d'ouverture

### DIFF
--- a/BUGS_compteur_ouverture.md
+++ b/BUGS_compteur_ouverture.md
@@ -1,0 +1,3 @@
+# Suivi des bugs - Compteur d'heures d'ouverture
+
+Aucun bug connu pour le moment.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,6 +7,7 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 - **Chargement de projet** : le code permet de recharger un planning précédemment sauvegardé.
 - **Planification** : pour chaque jour de la semaine, l'utilisateur peut ajouter autant de tranches d'ouverture qu'il le souhaite. Pour chaque tranche, un pharmacien est attribué pour la semaine 1 et la semaine 2.
 - **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien pour chaque semaine et affiche également le total sur deux semaines. L'enregistrement est désactivé si un pharmacien dépasse 70 heures.
+- **Compteur d'ouverture** : un total des heures d'ouverture du lundi au samedi est affiché et se met à jour automatiquement lors de la modification des tranches.
 - **Sauvegarde** : les données sont enregistrées côté serveur dans un fichier `.save` nommé d'après le code du projet.
 - **Nettoyage** : à chaque chargement de la page, les fichiers `.save` plus anciens que 15 jours sont automatiquement supprimés.
 

--- a/index.php
+++ b/index.php
@@ -122,6 +122,7 @@ if ($new && !$code) {
                     <tr><td>Pharmacien B</td><td id="w1B">0</td><td id="w2B">0</td><td id="totB">0</td></tr>
                 </tbody>
             </table>
+            <p>Heures d'ouverture (Lun-Sam) : <span id="openHours">0</span></p>
         </div>
     </div>
     <p class="code-info">Code du projet: <strong><?php echo htmlspecialchars($code); ?></strong></p>

--- a/script.js
+++ b/script.js
@@ -41,7 +41,9 @@ function renumberSegments(day){
 
 function calculateHours(){
     const totals = {A:{w1:0,w2:0}, B:{w1:0,w2:0}};
+    let openHours = 0;
     document.querySelectorAll('.segments').forEach(dayContainer=>{
+        const dayIndex = parseInt(dayContainer.dataset.day,10);
         dayContainer.querySelectorAll('.segment').forEach(seg=>{
             const start = seg.querySelector('input[name$="[start]"]').value;
             const end = seg.querySelector('input[name$="[end]"]').value;
@@ -51,6 +53,7 @@ function calculateHours(){
                 const ph2 = seg.querySelector('select[name$="[ph2]"]').value;
                 totals[ph1].w1 += diff;
                 totals[ph2].w2 += diff;
+                if(dayIndex < 6) openHours += diff;
             }
         });
     });
@@ -60,6 +63,7 @@ function calculateHours(){
     document.getElementById('w2B').textContent = totals.B.w2;
     document.getElementById('totA').textContent = totals.A.w1 + totals.A.w2;
     document.getElementById('totB').textContent = totals.B.w1 + totals.B.w2;
+    document.getElementById('openHours').textContent = openHours;
     const saveBtn=document.getElementById('saveBtn');
     if(totals.A.w1 + totals.A.w2 > 70 || totals.B.w1 + totals.B.w2 > 70){
         saveBtn.disabled=true;


### PR DESCRIPTION
## Summary
- Affiche les heures d'ouverture totales de lundi à samedi et mise à jour dynamique
- Calcule les heures pour l'ensemble de la semaine lors des modifications de segments
- Documentation et fichier de suivi des bugs mis à jour

## Testing
- `php -l index.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aeec1c54448320b11ae26cbb100d1f