### PR TITLE
Add weekly opening hours counter

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -6,13 +6,13 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 - **Création de projet** : l'utilisateur génère un code unique permettant d'identifier un planning.
 - **Chargement de projet** : le code permet de recharger un planning précédemment sauvegardé.
 - **Planification** : pour chaque jour de la semaine, l'utilisateur peut ajouter autant de tranches d'ouverture qu'il le souhaite. Pour chaque tranche, un pharmacien est attribué pour la semaine 1 et la semaine 2.
-- **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien pour chaque semaine et affiche également le total sur deux semaines. L'enregistrement est désactivé si un pharmacien dépasse 70 heures.
+- **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien pour chaque semaine, le total sur deux semaines ainsi que le nombre d'heures d'ouverture (lundi-samedi). L'enregistrement est désactivé si un pharmacien dépasse 70 heures.
 - **Sauvegarde** : les données sont enregistrées côté serveur dans un fichier `.save` nommé d'après le code du projet.
 - **Nettoyage** : à chaque chargement de la page, les fichiers `.save` plus anciens que 15 jours sont automatiquement supprimés.
 
 ## Structure des fichiers
 - **`index.php`** : point d'entrée de l'application. Gère la création ou le chargement d'un projet, lit et écrit les données dans les fichiers `.save` et génère le formulaire HTML du planning.
-- **`script.js`** : met à jour dynamiquement le nombre d'heures attribuées à chaque pharmacien et empêche la sauvegarde si le seuil de 70 heures est dépassé.
+- **`script.js`** : met à jour dynamiquement le nombre d'heures attribuées à chaque pharmacien, calcule les heures d'ouverture du lundi au samedi et empêche la sauvegarde si le seuil de 70 heures est dépassé.
 - **`style.css`** : fournit le style visuel de l'application (mise en page, couleurs, responsivité, etc.).
 - **`README.md`** : brève présentation du projet.
 - **`AGENTS.md`** : instructions pour les contributeurs et suivi des bugs.

--- a/bugs/compteur_heures_ouverture.md
+++ b/bugs/compteur_heures_ouverture.md
@@ -1,0 +1,3 @@
+# Suivi des bugs - Compteur d'heures d'ouverture
+
+Aucun bug connu pour le moment.

--- a/index.php
+++ b/index.php
@@ -122,6 +122,7 @@ if ($new && !$code) {
                     <tr><td>Pharmacien B</td><td id="w1B">0</td><td id="w2B">0</td><td id="totB">0</td></tr>
                 </tbody>
             </table>
+            <p class="open-hours">Heures d'ouverture (Lun-Sam): <span id="openHours">0</span></p>
         </div>
     </div>
     <p class="code-info">Code du projet: <strong><?php echo htmlspecialchars($code); ?></strong></p>

--- a/script.js
+++ b/script.js
@@ -41,12 +41,15 @@ function renumberSegments(day){
 
 function calculateHours(){
     const totals = {A:{w1:0,w2:0}, B:{w1:0,w2:0}};
+    let openHours = 0;
     document.querySelectorAll('.segments').forEach(dayContainer=>{
+        const dayIndex = parseInt(dayContainer.dataset.day,10);
         dayContainer.querySelectorAll('.segment').forEach(seg=>{
             const start = seg.querySelector('input[name$="[start]"]').value;
             const end = seg.querySelector('input[name$="[end]"]').value;
             if(start && end){
                 const diff = (new Date('1970-01-01T'+end) - new Date('1970-01-01T'+start))/3600000;
+                if(dayIndex < 6) openHours += diff;
                 const ph1 = seg.querySelector('select[name$="[ph1]"]').value;
                 const ph2 = seg.querySelector('select[name$="[ph2]"]').value;
                 totals[ph1].w1 += diff;
@@ -60,6 +63,8 @@ function calculateHours(){
     document.getElementById('w2B').textContent = totals.B.w2;
     document.getElementById('totA').textContent = totals.A.w1 + totals.A.w2;
     document.getElementById('totB').textContent = totals.B.w1 + totals.B.w2;
+    const openHoursEl = document.getElementById('openHours');
+    if(openHoursEl) openHoursEl.textContent = openHours;
     const saveBtn=document.getElementById('saveBtn');
     if(totals.A.w1 + totals.A.w2 > 70 || totals.B.w1 + totals.B.w2 > 70){
         saveBtn.disabled=true;

--- a/style.css
+++ b/style.css
@@ -70,6 +70,7 @@ input[type="time"], select {
 .message {color: green;}
 .error {color: red;}
 .code-info {text-align: center; margin-top: 20px;}
+.open-hours {margin-top:10px; text-align:center;}
 @media (min-width:800px){
     .columns {flex-direction: row; align-items:flex-start;}
 }


### PR DESCRIPTION
## Summary
- display weekly opening-hours counter for Monday to Saturday
- compute and update opening hours dynamically in the planner
- document the new counter and add a bug tracking file

## Testing
- `php -l index.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aeec1c54448320b11ae26cbb100d1f