### PR TITLE
Eviter la mise en cache des fichiers statiques

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -20,4 +20,5 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 ## Notes
 - Les fichiers `.save` contiennent les données JSON des projets et ne sont pas versionnés.
 - Un suivi de bugs séparé doit être maintenu pour chaque fonctionnalité.
+- Les fichiers CSS et JS sont chargés avec un paramètre de version basé sur leur date de modification afin d'éviter les problèmes de cache.
 

--- a/bugs/cache_css_js.md
+++ b/bugs/cache_css_js.md
@@ -1,0 +1,8 @@
+# Suivi des bugs - Rechargement des fichiers CSS/JS
+
+## 2025-08-27
+### Problème
+Après modification des fichiers CSS ou JS, les navigateurs continuaient d'utiliser les anciennes versions mises en cache.
+
+### Correction
+Ajout d'un paramètre de version basé sur `filemtime` aux liens vers `style.css` et `script.js` dans `index.php` pour forcer le chargement de la dernière version des fichiers.

--- a/index.php
+++ b/index.php
@@ -42,7 +42,7 @@ if ($new && !$code) {
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Planning Pharmacie</title>
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="style.css?v=<?php echo filemtime('style.css'); ?>">
 </head>
 <body>
 <div class="container">
@@ -128,6 +128,6 @@ if ($new && !$code) {
     <p class="code-info">Code du projet: <strong><?php echo htmlspecialchars($code); ?></strong></p>
 <?php endif; ?>
 </div>
-<script src="script.js"></script>
+<script src="script.js?v=<?php echo filemtime('script.js'); ?>"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ajouter un paramètre de version basé sur `filemtime` aux liens CSS et JS afin d'éviter la mise en cache côté client
- Documenter le mécanisme de version dans la documentation du projet
- Consigner la résolution du bug de cache dans un fichier de suivi dédié

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68aeecc219808320bd8eff8fd71ef83d