### PR TITLE
Ajout de sections pour horaires, planning et récapitulatif

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -5,8 +5,10 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 ## Fonctionnement général
 - **Création de projet** : l'utilisateur génère un code unique permettant d'identifier un planning.
 - **Chargement de projet** : le code permet de recharger un planning précédemment sauvegardé.
-- **Planification** : pour chaque jour de la semaine, l'utilisateur peut ajouter autant de tranches d'ouverture qu'il le souhaite. Pour chaque tranche, un pharmacien est attribué pour la semaine 1 et la semaine 2.
-- **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien pour chaque semaine, le total sur deux semaines ainsi que le nombre d'heures d'ouverture (lundi-samedi). L'enregistrement est désactivé si un pharmacien dépasse 70 heures.
+- **Section 1 – Horaires d'ouverture** : pour chaque jour de la semaine, l'utilisateur peut ajouter autant de tranches d'ouverture qu'il le souhaite.
+- **Section 2 – Planning des pharmaciens** : pour chaque tranche définie, un pharmacien est attribué pour la semaine 1 et un autre pour la semaine 2.
+- **Section 3 – Récapitulatif** : affichage du total d'heures par pharmacien et du nombre d'heures d'ouverture (lundi-samedi).
+- **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien pour chaque semaine, le total sur deux semaines ainsi que le nombre d'heures d'ouverture. L'enregistrement est désactivé si un pharmacien dépasse 70 heures.
 - **Sauvegarde** : les données sont enregistrées côté serveur dans un fichier `.save` nommé d'après le code du projet.
 - **Nettoyage** : à chaque chargement de la page, les fichiers `.save` plus anciens que 15 jours sont automatiquement supprimés.
 

--- a/bugs/sections_planning.md
+++ b/bugs/sections_planning.md
@@ -1,0 +1,3 @@
+# Suivi des bugs - Sections du planning
+
+Aucun bug connu pour le moment.

--- a/index.php
+++ b/index.php
@@ -61,56 +61,88 @@ if ($new && !$code) {
     <?php if($message): ?><p class="message"><?php echo htmlspecialchars($message); ?></p><?php endif; ?>
     <div class="columns">
         <div class="planner">
-            <h2>Ce que vous avez fait aujourd'hui</h2>
             <form method="post" id="scheduleForm">
                 <input type="hidden" name="code" value="<?php echo htmlspecialchars($code); ?>">
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Jour</th>
-                            <th>Tranches d'ouverture</th>
-                            <th></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <?php
-                        $daysNames = ['Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi','Dimanche'];
-                        for($day=0;$day<7;$day++){
-                            $segments = $data['schedule'][$day] ?? [];
-                            echo '<tr>';
-                            echo '<td>'.$daysNames[$day].'</td>';
-                            echo '<td class="segments" data-day="'.$day.'">';
-                            foreach($segments as $i=>$seg){
-                                $start = htmlspecialchars($seg['start'] ?? '');
-                                $end = htmlspecialchars($seg['end'] ?? '');
-                                $ph1 = $seg['ph1'] ?? 'A';
-                                $ph2 = $seg['ph2'] ?? 'A';
-                                echo '<div class="segment">'
-                                    .'<input type="time" name="schedule['.$day.']['.$i.'][start]" value="'.$start.'">'
-                                    .'<input type="time" name="schedule['.$day.']['.$i.'][end]" value="'.$end.'">'
-                                    .'<select name="schedule['.$day.']['.$i.'][ph1]">'
-                                        .'<option value="A"'.($ph1=='A'?' selected':'').'>A S1</option>'
-                                        .'<option value="B"'.($ph1=='B'?' selected':'').'>B S1</option>'
-                                    .'</select>'
-                                    .'<select name="schedule['.$day.']['.$i.'][ph2]">'
-                                        .'<option value="A"'.($ph2=='A'?' selected':'').'>A S2</option>'
-                                        .'<option value="B"'.($ph2=='B'?' selected':'').'>B S2</option>'
-                                    .'</select>'
-                                    .'<button type="button" class="remove-segment">&times;</button>'
-                                    .'</div>';
+                <?php $daysNames = ['Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi','Dimanche']; ?>
+                <div class="section section-openings">
+                    <h2>Section 1 : Horaires d'ouverture</h2>
+                    <table class="openings">
+                        <thead>
+                            <tr>
+                                <th>Jour</th>
+                                <th>Tranches d'ouverture</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php
+                            for($day=0;$day<7;$day++){
+                                $segments = $data['schedule'][$day] ?? [];
+                                echo '<tr>';
+                                echo '<td>'.$daysNames[$day].'</td>';
+                                echo '<td class="segments-open" data-day="'.$day.'">';
+                                foreach($segments as $i=>$seg){
+                                    $start = htmlspecialchars($seg['start'] ?? '');
+                                    $end = htmlspecialchars($seg['end'] ?? '');
+                                    echo '<div class="segment" data-index="'.$i.'">'
+                                        .'<input type="time" name="schedule['.$day.']['.$i.'][start]" value="'.$start.'">'
+                                        .'<input type="time" name="schedule['.$day.']['.$i.'][end]" value="'.$end.'">'
+                                        .'<button type="button" class="remove-segment">&times;</button>'
+                                        .'</div>';
+                                }
+                                echo '</td>';
+                                echo '<td><button type="button" class="add-segment" data-day="'.$day.'">Ajouter tranche</button></td>';
+                                echo '</tr>';
                             }
-                            echo '</td>';
-                            echo '<td><button type="button" class="add-segment" data-day="'.$day.'">Ajouter tranche</button></td>';
-                            echo '</tr>';
-                        }
-                        ?>
-                    </tbody>
-                </table>
+                            ?>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="section section-pharmacists">
+                    <h2>Section 2 : Planning des pharmaciens</h2>
+                    <table class="planning">
+                        <thead>
+                            <tr>
+                                <th>Jour</th>
+                                <th>Planning</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php
+                            for($day=0;$day<7;$day++){
+                                $segments = $data['schedule'][$day] ?? [];
+                                echo '<tr>';
+                                echo '<td>'.$daysNames[$day].'</td>';
+                                echo '<td class="segments-pharm" data-day="'.$day.'">';
+                                foreach($segments as $i=>$seg){
+                                    $start = htmlspecialchars($seg['start'] ?? '');
+                                    $end = htmlspecialchars($seg['end'] ?? '');
+                                    $ph1 = $seg['ph1'] ?? 'A';
+                                    $ph2 = $seg['ph2'] ?? 'A';
+                                    echo '<div class="segment" data-index="'.$i.'">'
+                                        .'<span class="time-range">'.$start.' - '.$end.'</span>'
+                                        .'<select name="schedule['.$day.']['.$i.'][ph1]">'
+                                            .'<option value="A"'.($ph1=='A'?' selected':'').'>A S1</option>'
+                                            .'<option value="B"'.($ph1=='B'?' selected':'').'>B S1</option>'
+                                        .'</select>'
+                                        .'<select name="schedule['.$day.']['.$i.'][ph2]">'
+                                            .'<option value="A"'.($ph2=='A'?' selected':'').'>A S2</option>'
+                                            .'<option value="B"'.($ph2=='B'?' selected':'').'>B S2</option>'
+                                        .'</select>'
+                                        .'</div>';
+                                }
+                                echo '</td>';
+                                echo '</tr>';
+                            }
+                            ?>
+                        </tbody>
+                    </table>
+                </div>
                 <button class="btn" type="submit" name="save" id="saveBtn">Sauvegarder</button>
             </form>
         </div>
         <div class="summary">
-            <h2>Récapitulatif</h2>
+            <h2>Section 3 : Récapitulatif</h2>
             <table class="recap">
                 <thead>
                     <tr>

--- a/script.js
+++ b/script.js
@@ -1,12 +1,33 @@
-function addSegment(day, data={}) {
-    const container = document.querySelector(`.segments[data-day="${day}"]`);
-    if (!container) return;
-    const index = container.querySelectorAll('.segment').length;
-    const seg = document.createElement('div');
-    seg.className = 'segment';
-    seg.innerHTML = `
+function updateTimeRange(day, index){
+    const openSeg = document.querySelector(`.segments-open[data-day="${day}"] .segment[data-index="${index}"]`);
+    const pharmSeg = document.querySelector(`.segments-pharm[data-day="${day}"] .segment[data-index="${index}"]`);
+    if(!openSeg || !pharmSeg) return;
+    const start = openSeg.querySelector('input[name$="[start]"]').value;
+    const end = openSeg.querySelector('input[name$="[end]"]').value;
+    pharmSeg.querySelector('.time-range').textContent = `${start} - ${end}`;
+}
+
+function addSegment(day, data={}){
+    const openContainer = document.querySelector(`.segments-open[data-day="${day}"]`);
+    const pharmContainer = document.querySelector(`.segments-pharm[data-day="${day}"]`);
+    if(!openContainer || !pharmContainer) return;
+    const index = openContainer.querySelectorAll('.segment').length;
+
+    const segOpen = document.createElement('div');
+    segOpen.className = 'segment';
+    segOpen.dataset.index = index;
+    segOpen.innerHTML = `
         <input type="time" name="schedule[${day}][${index}][start]" value="${data.start||''}">
         <input type="time" name="schedule[${day}][${index}][end]" value="${data.end||''}">
+        <button type="button" class="remove-segment">&times;</button>
+    `;
+    openContainer.appendChild(segOpen);
+
+    const segPharm = document.createElement('div');
+    segPharm.className = 'segment';
+    segPharm.dataset.index = index;
+    segPharm.innerHTML = `
+        <span class="time-range">${data.start||''} - ${data.end||''}</span>
         <select name="schedule[${day}][${index}][ph1]">
             <option value="A" ${data.ph1==='B'?'':'selected'}>A S1</option>
             <option value="B" ${data.ph1==='B'?'selected':''}>B S1</option>
@@ -15,48 +36,69 @@ function addSegment(day, data={}) {
             <option value="A" ${data.ph2==='B'?'':'selected'}>A S2</option>
             <option value="B" ${data.ph2==='B'?'selected':''}>B S2</option>
         </select>
-        <button type="button" class="remove-segment">&times;</button>
     `;
-    container.appendChild(seg);
-    seg.querySelectorAll('input, select').forEach(el => el.addEventListener('change', calculateHours));
-    seg.querySelector('.remove-segment').addEventListener('click', () => {
-        seg.remove();
+    pharmContainer.appendChild(segPharm);
+
+    segOpen.querySelectorAll('input').forEach(el=>{
+        el.addEventListener('change', ()=>{
+            updateTimeRange(day, index);
+            calculateHours();
+        });
+    });
+    segOpen.querySelector('.remove-segment').addEventListener('click', ()=>{
+        segOpen.remove();
+        segPharm.remove();
         renumberSegments(day);
         calculateHours();
     });
+    segPharm.querySelectorAll('select').forEach(el=>el.addEventListener('change', calculateHours));
     calculateHours();
 }
 
 function renumberSegments(day){
-    const container = document.querySelector(`.segments[data-day="${day}"]`);
-    container.querySelectorAll('.segment').forEach((seg,i)=>{
-        seg.querySelectorAll('input, select').forEach(el=>{
+    const openContainer = document.querySelector(`.segments-open[data-day="${day}"]`);
+    const pharmContainer = document.querySelector(`.segments-pharm[data-day="${day}"]`);
+    openContainer.querySelectorAll('.segment').forEach((seg,i)=>{
+        seg.dataset.index = i;
+        seg.querySelectorAll('input').forEach(el=>{
             if(el.name.includes('[start]')) el.name = `schedule[${day}][${i}][start]`;
             if(el.name.includes('[end]')) el.name = `schedule[${day}][${i}][end]`;
+        });
+    });
+    pharmContainer.querySelectorAll('.segment').forEach((seg,i)=>{
+        seg.dataset.index = i;
+        seg.querySelectorAll('select').forEach(el=>{
             if(el.name.includes('[ph1]')) el.name = `schedule[${day}][${i}][ph1]`;
             if(el.name.includes('[ph2]')) el.name = `schedule[${day}][${i}][ph2]`;
         });
     });
+    pharmContainer.querySelectorAll('.segment').forEach(seg=>updateTimeRange(day, seg.dataset.index));
 }
 
 function calculateHours(){
     const totals = {A:{w1:0,w2:0}, B:{w1:0,w2:0}};
     let openHours = 0;
-    document.querySelectorAll('.segments').forEach(dayContainer=>{
-        const dayIndex = parseInt(dayContainer.dataset.day,10);
-        dayContainer.querySelectorAll('.segment').forEach(seg=>{
+    for(let day=0; day<7; day++){
+        const openContainer = document.querySelector(`.segments-open[data-day="${day}"]`);
+        const pharmContainer = document.querySelector(`.segments-pharm[data-day="${day}"]`);
+        if(!openContainer || !pharmContainer) continue;
+        openContainer.querySelectorAll('.segment').forEach(seg=>{
+            const index = seg.dataset.index;
             const start = seg.querySelector('input[name$="[start]"]').value;
             const end = seg.querySelector('input[name$="[end]"]').value;
             if(start && end){
                 const diff = (new Date('1970-01-01T'+end) - new Date('1970-01-01T'+start))/3600000;
-                if(dayIndex < 6) openHours += diff;
-                const ph1 = seg.querySelector('select[name$="[ph1]"]').value;
-                const ph2 = seg.querySelector('select[name$="[ph2]"]').value;
-                totals[ph1].w1 += diff;
-                totals[ph2].w2 += diff;
+                if(day < 6) openHours += diff;
+                const pharmSeg = pharmContainer.querySelector(`.segment[data-index="${index}"]`);
+                if(pharmSeg){
+                    const ph1 = pharmSeg.querySelector('select[name$="[ph1]"]').value;
+                    const ph2 = pharmSeg.querySelector('select[name$="[ph2]"]').value;
+                    totals[ph1].w1 += diff;
+                    totals[ph2].w2 += diff;
+                }
             }
         });
-    });
+    }
     document.getElementById('w1A').textContent = totals.A.w1;
     document.getElementById('w1B').textContent = totals.B.w1;
     document.getElementById('w2A').textContent = totals.A.w2;
@@ -79,14 +121,28 @@ if(document.getElementById('scheduleForm')){
     document.querySelectorAll('.add-segment').forEach(btn=>{
         btn.addEventListener('click',()=>addSegment(btn.dataset.day));
     });
-    document.querySelectorAll('.segment').forEach(seg=>{
-        seg.querySelectorAll('input, select').forEach(el=>el.addEventListener('change', calculateHours));
-        seg.querySelector('.remove-segment').addEventListener('click',()=>{
-            const day = seg.closest('.segments').dataset.day;
-            seg.remove();
-            renumberSegments(day);
-            calculateHours();
+    document.querySelectorAll('.segments-open').forEach(dayContainer=>{
+        const day = dayContainer.dataset.day;
+        dayContainer.querySelectorAll('.segment').forEach(seg=>{
+            const index = seg.dataset.index;
+            seg.querySelectorAll('input').forEach(el=>{
+                el.addEventListener('change',()=>{
+                    updateTimeRange(day, index);
+                    calculateHours();
+                });
+            });
+            seg.querySelector('.remove-segment').addEventListener('click',()=>{
+                const pharmSeg = document.querySelector(`.segments-pharm[data-day="${day}"] .segment[data-index="${index}"]`);
+                if(pharmSeg) pharmSeg.remove();
+                seg.remove();
+                renumberSegments(day);
+                calculateHours();
+            });
         });
+    });
+    document.querySelectorAll('.segments-pharm .segment').forEach(seg=>{
+        seg.querySelectorAll('select').forEach(el=>el.addEventListener('change', calculateHours));
     });
     calculateHours();
 }
+

--- a/style.css
+++ b/style.css
@@ -53,11 +53,17 @@ th, td {
     gap: 20px;
 }
 .planner, .summary {flex:1;}
-.segments .segment {
+.section {margin-bottom:30px;}
+.segments-open .segment,
+.segments-pharm .segment {
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 6px;
+}
+.segments-pharm .time-range {
+    min-width: 120px;
+    align-self: center;
 }
 input[type="time"], select {
     padding: 6px;


### PR DESCRIPTION
## Summary
- Séparation de l'interface en trois sections : définition des horaires d'ouverture, affectation des pharmaciens et récapitulatif.
- Synchronisation des sections côté JavaScript avec recalcul automatique des heures et contrôle des dépassements.
- Styles mis à jour pour gérer les deux zones de saisie et la présentation du planning.

## Testing
- `php -l index.php`
- `node --check script.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68aeee4a42ec8320820f6bc3e29b864b