### PR TITLE
feat: allow customizing pharmacist names and colors

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -5,6 +5,7 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 ## Fonctionnement général
 - **Création de projet** : l'utilisateur génère un code unique permettant d'identifier un planning.
 - **Chargement de projet** : le code permet de recharger un planning précédemment sauvegardé.
+- **Section 0 – Options** : permet de définir un nom et une couleur pour chacun des deux pharmaciens.
 - **Section 1 – Horaires d'ouverture** : pour chaque jour de la semaine, l'utilisateur peut ajouter autant de tranches d'ouverture qu'il le souhaite.
 - **Section 2 – Planning des pharmaciens** : pour chaque tranche définie, un pharmacien est attribué pour la semaine 1 et un autre pour la semaine 2.
 - **Section 3 – Récapitulatif** : affichage du total d'heures par pharmacien et du nombre d'heures d'ouverture (lundi-samedi).

--- a/index.php
+++ b/index.php
@@ -14,11 +14,18 @@ $code = $_GET['code'] ?? null;
 $new = isset($_GET['new']);
 $message = '';
 $error = '';
-$data = ['schedule'=>[]];
+$data = [
+    'schedule'=>[],
+    'pharmacists'=>[
+        'A'=>['name'=>'Pharmacien A','color'=>'#ff6666'],
+        'B'=>['name'=>'Pharmacien B','color'=>'#6666ff']
+    ]
+];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save'])) {
     $code = preg_replace('/\D/', '', $_POST['code']);
     $data['schedule'] = $_POST['schedule'] ?? [];
+    $data['pharmacists'] = $_POST['pharmacists'] ?? $data['pharmacists'];
     file_put_contents("$code.save", json_encode($data));
     $message = 'Projet sauvegardé.';
 }
@@ -30,6 +37,12 @@ if ($new && !$code) {
     if (file_exists("$code.save")) {
         $content = file_get_contents("$code.save");
         $data = json_decode($content, true) ?: $data;
+        if(!isset($data['pharmacists'])){
+            $data['pharmacists'] = [
+                'A'=>['name'=>'Pharmacien A','color'=>'#ff6666'],
+                'B'=>['name'=>'Pharmacien B','color'=>'#6666ff']
+            ];
+        }
     } else {
         $error = 'Projet introuvable.';
         $code = null;
@@ -59,11 +72,23 @@ if ($new && !$code) {
 <?php else: ?>
     <h1>Projet #<?php echo htmlspecialchars($code); ?></h1>
     <?php if($message): ?><p class="message"><?php echo htmlspecialchars($message); ?></p><?php endif; ?>
+    <?php $pharmacists = $data['pharmacists']; ?>
     <div class="columns">
         <div class="planner">
             <form method="post" id="scheduleForm">
                 <input type="hidden" name="code" value="<?php echo htmlspecialchars($code); ?>">
                 <?php $daysNames = ['Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi','Dimanche']; ?>
+                <div class="section section-options">
+                    <h2>Section 0 : Options</h2>
+                    <div class="pharmacist-option">
+                        <label>Nom pharmacien A <input type="text" name="pharmacists[A][name]" value="<?php echo htmlspecialchars($pharmacists['A']['name']); ?>"></label>
+                        <label>Couleur <input type="color" name="pharmacists[A][color]" value="<?php echo htmlspecialchars($pharmacists['A']['color']); ?>"></label>
+                    </div>
+                    <div class="pharmacist-option">
+                        <label>Nom pharmacien B <input type="text" name="pharmacists[B][name]" value="<?php echo htmlspecialchars($pharmacists['B']['name']); ?>"></label>
+                        <label>Couleur <input type="color" name="pharmacists[B][color]" value="<?php echo htmlspecialchars($pharmacists['B']['color']); ?>"></label>
+                    </div>
+                </div>
                 <div class="section section-openings">
                     <h2>Section 1 : Horaires d'ouverture</h2>
                     <table class="openings">
@@ -121,13 +146,13 @@ if ($new && !$code) {
                                     $ph2 = $seg['ph2'] ?? 'A';
                                     echo '<div class="segment" data-index="'.$i.'">'
                                         .'<span class="time-range">'.$start.' - '.$end.'</span>'
-                                        .'<select name="schedule['.$day.']['.$i.'][ph1]">'
-                                            .'<option value="A"'.($ph1=='A'?' selected':'').'>A S1</option>'
-                                            .'<option value="B"'.($ph1=='B'?' selected':'').'>B S1</option>'
+                                        .'<select name="schedule['.$day.']['.$i.'][ph1]" class="ph-select" data-slot="S1">'
+                                            .'<option value="A"'.($ph1=='A'?' selected':'').' style="background-color:'.$pharmacists['A']['color'].'">'.htmlspecialchars($pharmacists['A']['name']).' S1</option>'
+                                            .'<option value="B"'.($ph1=='B'?' selected':'').' style="background-color:'.$pharmacists['B']['color'].'">'.htmlspecialchars($pharmacists['B']['name']).' S1</option>'
                                         .'</select>'
-                                        .'<select name="schedule['.$day.']['.$i.'][ph2]">'
-                                            .'<option value="A"'.($ph2=='A'?' selected':'').'>A S2</option>'
-                                            .'<option value="B"'.($ph2=='B'?' selected':'').'>B S2</option>'
+                                        .'<select name="schedule['.$day.']['.$i.'][ph2]" class="ph-select" data-slot="S2">'
+                                            .'<option value="A"'.($ph2=='A'?' selected':'').' style="background-color:'.$pharmacists['A']['color'].'">'.htmlspecialchars($pharmacists['A']['name']).' S2</option>'
+                                            .'<option value="B"'.($ph2=='B'?' selected':'').' style="background-color:'.$pharmacists['B']['color'].'">'.htmlspecialchars($pharmacists['B']['name']).' S2</option>'
                                         .'</select>'
                                         .'</div>';
                                 }
@@ -150,8 +175,8 @@ if ($new && !$code) {
                     </tr>
                 </thead>
                 <tbody>
-                    <tr><td>Pharmacien A</td><td id="w1A">0</td><td id="w2A">0</td><td id="totA">0</td></tr>
-                    <tr><td>Pharmacien B</td><td id="w1B">0</td><td id="w2B">0</td><td id="totB">0</td></tr>
+                    <tr><td id="labelA" style="color: <?php echo htmlspecialchars($pharmacists['A']['color']); ?>"><?php echo htmlspecialchars($pharmacists['A']['name']); ?></td><td id="w1A">0</td><td id="w2A">0</td><td id="totA">0</td></tr>
+                    <tr><td id="labelB" style="color: <?php echo htmlspecialchars($pharmacists['B']['color']); ?>"><?php echo htmlspecialchars($pharmacists['B']['name']); ?></td><td id="w1B">0</td><td id="w2B">0</td><td id="totB">0</td></tr>
                 </tbody>
             </table>
             <p class="open-hours">Heures d'ouverture (Lun-Sam): <span id="openHours">0</span></p>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,35 @@
+function getPharmacistInfo(){
+    return {
+        A:{
+            name: document.querySelector('input[name="pharmacists[A][name]"]').value || 'A',
+            color: document.querySelector('input[name="pharmacists[A][color]"]').value || '#ff6666'
+        },
+        B:{
+            name: document.querySelector('input[name="pharmacists[B][name]"]').value || 'B',
+            color: document.querySelector('input[name="pharmacists[B][color]"]').value || '#6666ff'
+        }
+    };
+}
+
+function applySelectStyles(){
+    const info = getPharmacistInfo();
+    document.querySelectorAll('.ph-select').forEach(sel=>{
+        const ph = sel.value;
+        sel.style.backgroundColor = info[ph].color;
+        sel.style.color = '#fff';
+        sel.options[0].textContent = `${info.A.name} ${sel.dataset.slot}`;
+        sel.options[0].style.backgroundColor = info.A.color;
+        sel.options[0].style.color = '#fff';
+        sel.options[1].textContent = `${info.B.name} ${sel.dataset.slot}`;
+        sel.options[1].style.backgroundColor = info.B.color;
+        sel.options[1].style.color = '#fff';
+    });
+    const labelA = document.getElementById('labelA');
+    const labelB = document.getElementById('labelB');
+    if(labelA){ labelA.textContent = info.A.name; labelA.style.color = info.A.color; }
+    if(labelB){ labelB.textContent = info.B.name; labelB.style.color = info.B.color; }
+}
+
 function updateTimeRange(day, index){
     const openSeg = document.querySelector(`.segments-open[data-day="${day}"] .segment[data-index="${index}"]`);
     const pharmSeg = document.querySelector(`.segments-pharm[data-day="${day}"] .segment[data-index="${index}"]`);
@@ -23,18 +55,19 @@ function addSegment(day, data={}){
     `;
     openContainer.appendChild(segOpen);
 
+    const info = getPharmacistInfo();
     const segPharm = document.createElement('div');
     segPharm.className = 'segment';
     segPharm.dataset.index = index;
     segPharm.innerHTML = `
         <span class="time-range">${data.start||''} - ${data.end||''}</span>
-        <select name="schedule[${day}][${index}][ph1]">
-            <option value="A" ${data.ph1==='B'?'':'selected'}>A S1</option>
-            <option value="B" ${data.ph1==='B'?'selected':''}>B S1</option>
+        <select name="schedule[${day}][${index}][ph1]" class="ph-select" data-slot="S1">
+            <option value="A" ${data.ph1==='B'?'':'selected'}>${info.A.name} S1</option>
+            <option value="B" ${data.ph1==='B'?'selected':''}>${info.B.name} S1</option>
         </select>
-        <select name="schedule[${day}][${index}][ph2]">
-            <option value="A" ${data.ph2==='B'?'':'selected'}>A S2</option>
-            <option value="B" ${data.ph2==='B'?'selected':''}>B S2</option>
+        <select name="schedule[${day}][${index}][ph2]" class="ph-select" data-slot="S2">
+            <option value="A" ${data.ph2==='B'?'':'selected'}>${info.A.name} S2</option>
+            <option value="B" ${data.ph2==='B'?'selected':''}>${info.B.name} S2</option>
         </select>
     `;
     pharmContainer.appendChild(segPharm);
@@ -51,7 +84,10 @@ function addSegment(day, data={}){
         renumberSegments(day);
         calculateHours();
     });
-    segPharm.querySelectorAll('select').forEach(el=>el.addEventListener('change', calculateHours));
+    segPharm.querySelectorAll('select').forEach(el=>{
+        el.addEventListener('change', ()=>{applySelectStyles();calculateHours();});
+    });
+    applySelectStyles();
     calculateHours();
 }
 
@@ -141,8 +177,10 @@ if(document.getElementById('scheduleForm')){
         });
     });
     document.querySelectorAll('.segments-pharm .segment').forEach(seg=>{
-        seg.querySelectorAll('select').forEach(el=>el.addEventListener('change', calculateHours));
+        seg.querySelectorAll('select').forEach(el=>el.addEventListener('change', ()=>{applySelectStyles();calculateHours();}));
     });
+    document.querySelectorAll('input[name^="pharmacists"]').forEach(inp=>inp.addEventListener('input', applySelectStyles));
+    applySelectStyles();
     calculateHours();
 }
 

--- a/style.css
+++ b/style.css
@@ -70,6 +70,15 @@ input[type="time"], select {
     border: 1px solid #ccc;
     border-radius: 6px;
 }
+.section-options .pharmacist-option {
+    display:flex;
+    align-items:center;
+    gap:10px;
+    margin-bottom:10px;
+}
+.ph-select {
+    color:#fff;
+}
 .add-segment {padding:6px 10px;}
 .summary table {width:100%; border-collapse: collapse;}
 .summary th, .summary td {border-bottom:1px solid #ccc; padding:8px; text-align:center;}


### PR DESCRIPTION
## Summary
- add an options section to set pharmacist names and color codes
- colorize planning selects and summary according to chosen colors
- document new options feature

## Testing
- `php -l index.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aef32fcfec8320815f5ebf4bf84f33