### PR TITLE
Allow custom pharmacist planning segments

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,7 +7,7 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 - **Chargement de projet** : le code permet de recharger un planning précédemment sauvegardé.
 - **Section 0 – Options** : permet de définir un nom et une couleur pour chacun des deux pharmaciens.
 - **Section 1 – Horaires d'ouverture** : pour chaque jour de la semaine, l'utilisateur peut ajouter autant de tranches d'ouverture qu'il le souhaite.
-- **Section 2 – Planning des pharmaciens** : pour chaque tranche définie, un pharmacien est attribué pour la semaine 1 et un autre pour la semaine 2.
+- **Section 2 – Planning des pharmaciens** : des tranches indépendantes peuvent être ajoutées librement pour chaque jour afin d'assigner un pharmacien pour la semaine 1 et un autre pour la semaine 2.
 - **Section 3 – Récapitulatif** : affichage du total d'heures par pharmacien et du nombre d'heures d'ouverture (lundi-samedi).
 - **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien pour chaque semaine, le total sur deux semaines ainsi que le nombre d'heures d'ouverture. L'enregistrement est désactivé si un pharmacien dépasse 70 heures.
 - **Sauvegarde** : les données sont enregistrées côté serveur dans un fichier `.save` nommé d'après le code du projet.
@@ -15,7 +15,7 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 
 ## Structure des fichiers
 - **`index.php`** : point d'entrée de l'application. Gère la création ou le chargement d'un projet, lit et écrit les données dans les fichiers `.save` et génère le formulaire HTML du planning.
-- **`script.js`** : met à jour dynamiquement le nombre d'heures attribuées à chaque pharmacien, calcule les heures d'ouverture du lundi au samedi et empêche la sauvegarde si le seuil de 70 heures est dépassé.
+- **`script.js`** : gère l'ajout des tranches d'ouverture et des tranches de planning, met à jour dynamiquement le nombre d'heures attribuées à chaque pharmacien, calcule les heures d'ouverture du lundi au samedi et empêche la sauvegarde si le seuil de 70 heures est dépassé.
 - **`style.css`** : fournit le style visuel de l'application (mise en page, couleurs, responsivité, etc.).
 - **`README.md`** : brève présentation du projet.
 - **`AGENTS.md`** : instructions pour les contributeurs et suivi des bugs.

--- a/bugs/sections_planning.md
+++ b/bugs/sections_planning.md
@@ -1,3 +1,5 @@
 # Suivi des bugs - Sections du planning
 
-Aucun bug connu pour le moment.
+## 2025-08-27
+- **Problème** : l'ajout d'une tranche d'ouverture créait automatiquement un segment de planning couvrant toute la tranche, empêchant de définir plusieurs pharmaciens sur des horaires différents.
+- **Résolution** : séparation du planning des pharmaciens des horaires d'ouverture. Les tranches de planning peuvent maintenant être ajoutées ou supprimées indépendamment, avec choix des heures et du pharmacien.

--- a/script.js
+++ b/script.js
@@ -30,85 +30,84 @@ function applySelectStyles(){
     if(labelB){ labelB.textContent = info.B.name; labelB.style.color = info.B.color; }
 }
 
-function updateTimeRange(day, index){
-    const openSeg = document.querySelector(`.segments-open[data-day="${day}"] .segment[data-index="${index}"]`);
-    const pharmSeg = document.querySelector(`.segments-pharm[data-day="${day}"] .segment[data-index="${index}"]`);
-    if(!openSeg || !pharmSeg) return;
-    const start = openSeg.querySelector('input[name$="[start]"]').value;
-    const end = openSeg.querySelector('input[name$="[end]"]').value;
-    pharmSeg.querySelector('.time-range').textContent = `${start} - ${end}`;
-}
-
-function addSegment(day, data={}){
-    const openContainer = document.querySelector(`.segments-open[data-day="${day}"]`);
-    const pharmContainer = document.querySelector(`.segments-pharm[data-day="${day}"]`);
-    if(!openContainer || !pharmContainer) return;
-    const index = openContainer.querySelectorAll('.segment').length;
-
-    const segOpen = document.createElement('div');
-    segOpen.className = 'segment';
-    segOpen.dataset.index = index;
-    segOpen.innerHTML = `
+function addOpenSegment(day, data={}){
+    const container = document.querySelector(`.segments-open[data-day="${day}"]`);
+    if(!container) return;
+    const index = container.querySelectorAll('.segment').length;
+    const seg = document.createElement('div');
+    seg.className = 'segment';
+    seg.dataset.index = index;
+    seg.innerHTML = `
         <input type="time" name="schedule[${day}][${index}][start]" value="${data.start||''}">
         <input type="time" name="schedule[${day}][${index}][end]" value="${data.end||''}">
         <button type="button" class="remove-segment">&times;</button>
     `;
-    openContainer.appendChild(segOpen);
-
-    const info = getPharmacistInfo();
-    const segPharm = document.createElement('div');
-    segPharm.className = 'segment';
-    segPharm.dataset.index = index;
-    segPharm.innerHTML = `
-        <span class="time-range">${data.start||''} - ${data.end||''}</span>
-        <select name="schedule[${day}][${index}][ph1]" class="ph-select" data-slot="S1">
-            <option value="A" ${data.ph1==='B'?'':'selected'}>${info.A.name} S1</option>
-            <option value="B" ${data.ph1==='B'?'selected':''}>${info.B.name} S1</option>
-        </select>
-        <select name="schedule[${day}][${index}][ph2]" class="ph-select" data-slot="S2">
-            <option value="A" ${data.ph2==='B'?'':'selected'}>${info.A.name} S2</option>
-            <option value="B" ${data.ph2==='B'?'selected':''}>${info.B.name} S2</option>
-        </select>
-    `;
-    pharmContainer.appendChild(segPharm);
-
-    segOpen.querySelectorAll('input').forEach(el=>{
-        el.addEventListener('change', ()=>{
-            updateTimeRange(day, index);
-            calculateHours();
-        });
-    });
-    segOpen.querySelector('.remove-segment').addEventListener('click', ()=>{
-        segOpen.remove();
-        segPharm.remove();
-        renumberSegments(day);
+    container.appendChild(seg);
+    seg.querySelectorAll('input').forEach(el=>el.addEventListener('change', calculateHours));
+    seg.querySelector('.remove-segment').addEventListener('click', ()=>{
+        seg.remove();
+        renumberOpenSegments(day);
         calculateHours();
     });
-    segPharm.querySelectorAll('select').forEach(el=>{
-        el.addEventListener('change', ()=>{applySelectStyles();calculateHours();});
-    });
-    applySelectStyles();
     calculateHours();
 }
 
-function renumberSegments(day){
-    const openContainer = document.querySelector(`.segments-open[data-day="${day}"]`);
-    const pharmContainer = document.querySelector(`.segments-pharm[data-day="${day}"]`);
-    openContainer.querySelectorAll('.segment').forEach((seg,i)=>{
+function renumberOpenSegments(day){
+    const container = document.querySelector(`.segments-open[data-day="${day}"]`);
+    container.querySelectorAll('.segment').forEach((seg,i)=>{
         seg.dataset.index = i;
         seg.querySelectorAll('input').forEach(el=>{
             if(el.name.includes('[start]')) el.name = `schedule[${day}][${i}][start]`;
             if(el.name.includes('[end]')) el.name = `schedule[${day}][${i}][end]`;
         });
     });
-    pharmContainer.querySelectorAll('.segment').forEach((seg,i)=>{
+}
+
+function addPharmSegment(day, data={}){
+    const container = document.querySelector(`.segments-pharm[data-day="${day}"]`);
+    if(!container) return;
+    const index = container.querySelectorAll('.segment').length;
+    const info = getPharmacistInfo();
+    const seg = document.createElement('div');
+    seg.className = 'segment';
+    seg.dataset.index = index;
+    seg.innerHTML = `
+        <input type="time" name="pharm_sched[${day}][${index}][start]" value="${data.start||''}">
+        <input type="time" name="pharm_sched[${day}][${index}][end]" value="${data.end||''}">
+        <select name="pharm_sched[${day}][${index}][ph1]" class="ph-select" data-slot="S1">
+            <option value="A" ${data.ph1==='B'?'':'selected'}>${info.A.name} S1</option>
+            <option value="B" ${data.ph1==='B'?'selected':''}>${info.B.name} S1</option>
+        </select>
+        <select name="pharm_sched[${day}][${index}][ph2]" class="ph-select" data-slot="S2">
+            <option value="A" ${data.ph2==='B'?'':'selected'}>${info.A.name} S2</option>
+            <option value="B" ${data.ph2==='B'?'selected':''}>${info.B.name} S2</option>
+        </select>
+        <button type="button" class="remove-pharm">&times;</button>
+    `;
+    const addBtn = container.querySelector('.add-pharm');
+    container.insertBefore(seg, addBtn);
+    seg.querySelectorAll('input').forEach(el=>el.addEventListener('change', calculateHours));
+    seg.querySelectorAll('select').forEach(el=>el.addEventListener('change', ()=>{applySelectStyles();calculateHours();}));
+    seg.querySelector('.remove-pharm').addEventListener('click', ()=>{
+        seg.remove();
+        renumberPharmSegments(day);
+        calculateHours();
+    });
+    applySelectStyles();
+    calculateHours();
+}
+
+function renumberPharmSegments(day){
+    const container = document.querySelector(`.segments-pharm[data-day="${day}"]`);
+    container.querySelectorAll('.segment').forEach((seg,i)=>{
         seg.dataset.index = i;
-        seg.querySelectorAll('select').forEach(el=>{
-            if(el.name.includes('[ph1]')) el.name = `schedule[${day}][${i}][ph1]`;
-            if(el.name.includes('[ph2]')) el.name = `schedule[${day}][${i}][ph2]`;
+        seg.querySelectorAll('input,select').forEach(el=>{
+            if(el.name.includes('[start]')) el.name = `pharm_sched[${day}][${i}][start]`;
+            if(el.name.includes('[end]')) el.name = `pharm_sched[${day}][${i}][end]`;
+            if(el.name.includes('[ph1]')) el.name = `pharm_sched[${day}][${i}][ph1]`;
+            if(el.name.includes('[ph2]')) el.name = `pharm_sched[${day}][${i}][ph2]`;
         });
     });
-    pharmContainer.querySelectorAll('.segment').forEach(seg=>updateTimeRange(day, seg.dataset.index));
 }
 
 function calculateHours(){
@@ -116,24 +115,30 @@ function calculateHours(){
     let openHours = 0;
     for(let day=0; day<7; day++){
         const openContainer = document.querySelector(`.segments-open[data-day="${day}"]`);
+        if(openContainer){
+            openContainer.querySelectorAll('.segment').forEach(seg=>{
+                const start = seg.querySelector('input[name$="[start]"]').value;
+                const end = seg.querySelector('input[name$="[end]"]').value;
+                if(start && end){
+                    const diff = (new Date('1970-01-01T'+end) - new Date('1970-01-01T'+start))/3600000;
+                    if(day < 6) openHours += diff;
+                }
+            });
+        }
         const pharmContainer = document.querySelector(`.segments-pharm[data-day="${day}"]`);
-        if(!openContainer || !pharmContainer) continue;
-        openContainer.querySelectorAll('.segment').forEach(seg=>{
-            const index = seg.dataset.index;
-            const start = seg.querySelector('input[name$="[start]"]').value;
-            const end = seg.querySelector('input[name$="[end]"]').value;
-            if(start && end){
-                const diff = (new Date('1970-01-01T'+end) - new Date('1970-01-01T'+start))/3600000;
-                if(day < 6) openHours += diff;
-                const pharmSeg = pharmContainer.querySelector(`.segment[data-index="${index}"]`);
-                if(pharmSeg){
-                    const ph1 = pharmSeg.querySelector('select[name$="[ph1]"]').value;
-                    const ph2 = pharmSeg.querySelector('select[name$="[ph2]"]').value;
+        if(pharmContainer){
+            pharmContainer.querySelectorAll('.segment').forEach(seg=>{
+                const start = seg.querySelector('input[name$="[start]"]').value;
+                const end = seg.querySelector('input[name$="[end]"]').value;
+                const ph1 = seg.querySelector('select[name$="[ph1]"]').value;
+                const ph2 = seg.querySelector('select[name$="[ph2]"]').value;
+                if(start && end){
+                    const diff = (new Date('1970-01-01T'+end) - new Date('1970-01-01T'+start))/3600000;
                     totals[ph1].w1 += diff;
                     totals[ph2].w2 += diff;
                 }
-            }
-        });
+            });
+        }
     }
     document.getElementById('w1A').textContent = totals.A.w1;
     document.getElementById('w1B').textContent = totals.B.w1;
@@ -143,42 +148,49 @@ function calculateHours(){
     document.getElementById('totB').textContent = totals.B.w1 + totals.B.w2;
     const openHoursEl = document.getElementById('openHours');
     if(openHoursEl) openHoursEl.textContent = openHours;
-    const saveBtn=document.getElementById('saveBtn');
+    const saveBtn = document.getElementById('saveBtn');
     if(totals.A.w1 + totals.A.w2 > 70 || totals.B.w1 + totals.B.w2 > 70){
-        saveBtn.disabled=true;
-        saveBtn.title='Un pharmacien dépasse 70h sur deux semaines';
+        saveBtn.disabled = true;
+        saveBtn.title = 'Un pharmacien dépasse 70h sur deux semaines';
     } else {
-        saveBtn.disabled=false;
-        saveBtn.title='';
+        saveBtn.disabled = false;
+        saveBtn.title = '';
     }
 }
 
 if(document.getElementById('scheduleForm')){
     document.querySelectorAll('.add-segment').forEach(btn=>{
-        btn.addEventListener('click',()=>addSegment(btn.dataset.day));
+        btn.addEventListener('click',()=>addOpenSegment(btn.dataset.day));
     });
     document.querySelectorAll('.segments-open').forEach(dayContainer=>{
         const day = dayContainer.dataset.day;
         dayContainer.querySelectorAll('.segment').forEach(seg=>{
-            const index = seg.dataset.index;
-            seg.querySelectorAll('input').forEach(el=>{
-                el.addEventListener('change',()=>{
-                    updateTimeRange(day, index);
-                    calculateHours();
-                });
-            });
+            seg.querySelectorAll('input').forEach(el=>el.addEventListener('change', calculateHours));
             seg.querySelector('.remove-segment').addEventListener('click',()=>{
-                const pharmSeg = document.querySelector(`.segments-pharm[data-day="${day}"] .segment[data-index="${index}"]`);
-                if(pharmSeg) pharmSeg.remove();
                 seg.remove();
-                renumberSegments(day);
+                renumberOpenSegments(day);
                 calculateHours();
             });
         });
     });
-    document.querySelectorAll('.segments-pharm .segment').forEach(seg=>{
-        seg.querySelectorAll('select').forEach(el=>el.addEventListener('change', ()=>{applySelectStyles();calculateHours();}));
+
+    document.querySelectorAll('.add-pharm').forEach(btn=>{
+        btn.addEventListener('click',()=>addPharmSegment(btn.dataset.day));
     });
+    document.querySelectorAll('.segments-pharm').forEach(dayContainer=>{
+        const day = dayContainer.dataset.day;
+        dayContainer.querySelectorAll('.segment').forEach(seg=>{
+            seg.querySelectorAll('input').forEach(el=>el.addEventListener('change', calculateHours));
+            seg.querySelectorAll('select').forEach(el=>el.addEventListener('change', ()=>{applySelectStyles();calculateHours();}));
+            const rem = seg.querySelector('.remove-pharm');
+            if(rem) rem.addEventListener('click',()=>{
+                seg.remove();
+                renumberPharmSegments(day);
+                calculateHours();
+            });
+        });
+    });
+
     document.querySelectorAll('input[name^="pharmacists"]').forEach(inp=>inp.addEventListener('input', applySelectStyles));
     applySelectStyles();
     calculateHours();


### PR DESCRIPTION
## Summary
- Separate pharmacist planning from opening hours
- Add manual planning segments with editable times
- Document independent planning and record fix

## Testing
- `php -l index.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aef440b7348320a05e3c4b6e3875b9