### PR TITLE
Empêcher les horaires pharmacien hors ouverture

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,7 +7,7 @@ Ce projet est une application web légère permettant de gérer les horaires d'o
 - **Chargement de projet** : le code permet de recharger un planning précédemment sauvegardé.
 - **Section 0 – Options** : permet de définir un nom et une couleur pour chacun des deux pharmaciens.
 - **Section 1 – Horaires d'ouverture** : pour chaque jour de la semaine, l'utilisateur peut ajouter autant de tranches d'ouverture qu'il le souhaite.
-- **Section 2 – Planning des pharmaciens** : des tranches indépendantes peuvent être ajoutées librement pour chaque jour afin d'assigner un pharmacien pour la semaine 1 et un autre pour la semaine 2.
+- **Section 2 – Planning des pharmaciens** : des tranches indépendantes peuvent être ajoutées pour chaque jour afin d'assigner un pharmacien pour la semaine 1 et un autre pour la semaine 2, mais elles doivent obligatoirement rester dans les horaires d'ouverture définis à la section 1.
 - **Section 3 – Récapitulatif** : affichage du total d'heures par pharmacien et du nombre d'heures d'ouverture (lundi-samedi).
 - **Calcul automatique** : le script JavaScript calcule en temps réel le nombre d'heures effectuées par chaque pharmacien pour chaque semaine, le total sur deux semaines ainsi que le nombre d'heures d'ouverture. L'enregistrement est désactivé si un pharmacien dépasse 70 heures.
  - **Sauvegarde** : les données sont enregistrées côté serveur dans un fichier `.save` nommé d'après le code du projet. Un message toast confirme la réussite (ou signale une erreur) et rappelle de noter le code.

--- a/bugs/sections_planning.md
+++ b/bugs/sections_planning.md
@@ -3,3 +3,7 @@
 ## 2025-08-27
 - **Problème** : l'ajout d'une tranche d'ouverture créait automatiquement un segment de planning couvrant toute la tranche, empêchant de définir plusieurs pharmaciens sur des horaires différents.
 - **Résolution** : séparation du planning des pharmaciens des horaires d'ouverture. Les tranches de planning peuvent maintenant être ajoutées ou supprimées indépendamment, avec choix des heures et du pharmacien.
+
+## 2025-08-28
+- **Problème** : possibilité d'ajouter un horaire de pharmacien en dehors des heures d'ouverture de l'officine.
+- **Résolution** : ajout de contrôles côté client et côté serveur. Le formulaire refuse désormais les tranches hors horaires d'ouverture et celles-ci sont ignorées à la sauvegarde.

--- a/index.php
+++ b/index.php
@@ -28,6 +28,25 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['save'])) {
     $data['schedule'] = $_POST['schedule'] ?? [];
     $data['pharm_sched'] = $_POST['pharm_sched'] ?? [];
     $data['pharmacists'] = $_POST['pharmacists'] ?? $data['pharmacists'];
+    $invalid = false;
+    foreach($data['pharm_sched'] as $d=>&$segs){
+        $opens = $data['schedule'][$d] ?? [];
+        foreach($segs as $i=>$seg){
+            $s = $seg['start'] ?? '';
+            $e = $seg['end'] ?? '';
+            $inside = false;
+            if($s && $e){
+                foreach($opens as $o){
+                    if($s >= ($o['start'] ?? '') && $e <= ($o['end'] ?? '')){ $inside = true; break; }
+                }
+            }
+            if(!$inside){ unset($segs[$i]); $invalid = true; }
+        }
+        $segs = array_values($segs);
+    }
+    if($invalid){
+        $error = 'Tranches pharmaciens hors horaires d\'ouverture ignorées.';
+    }
     if (file_put_contents("$code.save", json_encode($data)) !== false) {
         $message = 'Projet sauvegardé. Pensez à noter votre code d\'accès pour réouvrir votre travail.';
     } else {


### PR DESCRIPTION
## Summary
- Interdit l'ajout d'une tranche pharmacien lorsqu'aucune ouverture n'est définie pour le jour.
- Vérifie que chaque plage pharmacien reste dans une tranche d'ouverture, côté client et serveur.
- Documente la contrainte et trace le correctif dans le suivi des bugs.

## Testing
- `node -c script.js`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68aef6c101748320ace0f7307d246038