### PR TITLE
Improve visibility of 'Ajouter tranche' buttons

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -27,4 +27,5 @@ L'interface utilise Tailwind CSS et présente les différentes sections sous for
 - Les fichiers `.save` contiennent les données JSON des projets et ne sont pas versionnés.
 - Un suivi de bugs séparé doit être maintenu pour chaque fonctionnalité.
 - Les fichiers CSS et JS sont chargés avec un paramètre de version basé sur leur date de modification afin d'éviter les problèmes de cache.
+- Les boutons « Ajouter tranche » sont stylisés dans un esprit Apple pour être plus visibles.
 

--- a/bugs/sections_planning.md
+++ b/bugs/sections_planning.md
@@ -10,3 +10,7 @@
 
 ## 2025-08-29
 - **Amélioration** : refonte de l'interface avec Tailwind CSS. Les sections sont présentées sous forme de cartes, les sections 0 et 3 partagent une ligne en deux colonnes et les sections 1 et 2 occupent chacune toute la largeur.
+
+## 2025-08-30
+- **Problème** : les boutons "Ajouter tranche" étaient peu visibles et ne respectaient pas le design Apple.
+- **Résolution** : style unifié des boutons avec une couleur bleue, des coins arrondis et un symbole « + » pour améliorer la visibilité.

--- a/index.php
+++ b/index.php
@@ -172,7 +172,7 @@ if ($new && !$code) {
                                 .'</div>';
                         }
                         echo '</td>';
-                        echo '<td><button type="button" class="add-segment" data-day="'.$day.'">Ajouter tranche</button></td>';
+                        echo '<td><button type="button" class="add-segment" data-day="'.$day.'">+ Ajouter tranche</button></td>';
                         echo '</tr>';
                     }
                     ?>
@@ -214,7 +214,7 @@ if ($new && !$code) {
                             .'<button type="button" class="remove-pharm">&times;</button>'
                             .'</div>';
                     }
-                    echo '<button type="button" class="add-pharm" data-day="'.$day.'">Ajouter tranche</button>';
+                    echo '<button type="button" class="add-pharm" data-day="'.$day.'">+ Ajouter tranche</button>';
                     echo '</td>';
                     echo '</tr>';
                 }

--- a/style.css
+++ b/style.css
@@ -59,7 +59,20 @@ input[type="time"], select {
 .ph-select {
     color:#fff;
 }
-.add-segment {padding:6px 10px;}
+.add-segment, .add-pharm {
+    padding: 6px 12px;
+    background-color: #007aff;
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.add-segment:hover, .add-pharm:hover {
+    background-color: #0051c3;
+}
 .summary table {width:100%; border-collapse: collapse;}
 .summary th, .summary td {border-bottom:1px solid #ccc; padding:8px; text-align:center;}
 .message {color: green;}


### PR DESCRIPTION
## Summary
- Style "Ajouter tranche" buttons with an Apple-like blue rounded design and "+" symbol for clarity
- Document Apple-inspired styling in documentation and bug tracking

## Testing
- `php -l index.php`
- `php -l print.php`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aeffd587048320af83d8a2cce0f028