### PR TITLE
Add Meditrust footer

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -28,4 +28,5 @@ L'interface utilise Tailwind CSS et présente les différentes sections sous for
 - Un suivi de bugs séparé doit être maintenu pour chaque fonctionnalité.
 - Les fichiers CSS et JS sont chargés avec un paramètre de version basé sur leur date de modification afin d'éviter les problèmes de cache.
 - Les boutons « Ajouter tranche » sont stylisés dans un esprit Apple pour être plus visibles.
+- Le pied de page affiche « Fait avec amour par Meditrust pour les pharmacies » avec le logo redirigeant vers la page de contact.
 

--- a/index.php
+++ b/index.php
@@ -228,6 +228,12 @@ if ($new && !$code) {
     <p class="code-info"><a class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded inline-block" target="_blank" href="print.php?code=<?php echo htmlspecialchars($code); ?>">Planning imprimable (PDF)</a></p>
 <?php endif; ?>
 </div>
+<footer class="text-center text-sm mt-4">
+    Fait avec amour par Meditrust pour les pharmacies
+    <a href="https://meditrust.io/contacter-nous/" target="_blank">
+        <img src="https://meditrust.io/wp-content/uploads/2023/09/meditrust-logo-green.png" alt="Logo Meditrust" class="inline-block h-6 align-middle ml-2">
+    </a>
+</footer>
 <div id="toast" data-message="<?php echo htmlspecialchars($message); ?>" data-error="<?php echo htmlspecialchars($error); ?>"></div>
 <script src="script.js?v=<?php echo filemtime('script.js'); ?>"></script>
 </body>

--- a/print.php
+++ b/print.php
@@ -65,5 +65,11 @@ h2 { text-align: center; margin-top: 0; }
         </tbody>
     </table>
 <?php endfor; ?>
+<footer style="text-align:center;font-size:12px;margin-top:20px;">
+    Fait avec amour par Meditrust pour les pharmacies
+    <a href="https://meditrust.io/contacter-nous/" target="_blank">
+        <img src="https://meditrust.io/wp-content/uploads/2023/09/meditrust-logo-green.png" alt="Logo Meditrust" style="height:20px;vertical-align:middle;margin-left:4px;">
+    </a>
+</footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a footer message attributing the app to Meditrust and linking to the contact page via the logo
- document the new footer in project notes

## Testing
- `php -l index.php`
- `php -l print.php`


------
https://chatgpt.com/codex/tasks/task_e_68af0f3e27848320a6f6cbf898e9b07e