### PR TITLE
Add responsive help sidebar with open/close animations

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -15,6 +15,7 @@ L'interface utilise Tailwind CSS et présente les différentes sections sous for
  - **Sauvegarde** : les données sont enregistrées côté serveur dans un fichier `.save` nommé d'après le code du projet. Un message toast confirme la réussite (ou signale une erreur) et rappelle de noter le code.
 - **Nettoyage** : à chaque chargement de la page, les fichiers `.save` plus anciens que 15 jours sont automatiquement supprimés.
 - **Export PDF** : un bouton « Planning imprimable (PDF) » ouvre une vue A4 paysage (semaine 1 puis semaine 2) prête à être imprimée ou enregistrée en PDF.
+- **Aide intégrée** : un bouton « Aide » affiche une barre latérale expliquant les étapes d'utilisation de l'outil.
 
 ## Structure des fichiers
 - **`index.php`** : point d'entrée de l'application. Gère la création ou le chargement d'un projet, lit et écrit les données dans les fichiers `.save` et génère le formulaire HTML du planning.

--- a/bugs/sidebar_aide.md
+++ b/bugs/sidebar_aide.md
@@ -1,0 +1,8 @@
+# Suivi des bugs - Sidebar d'aide
+
+## 2025-08-27
+### Problème
+L'application ne proposait pas de panneau d'aide pour guider l'utilisateur.
+
+### Correction
+Ajout d'une sidebar d'aide avec effet de transition, responsive et refermable.

--- a/index.php
+++ b/index.php
@@ -99,6 +99,7 @@ if ($new && !$code) {
 <link rel="stylesheet" href="style.css?v=<?php echo filemtime('style.css'); ?>">
 </head>
 <body>
+<button id="helpToggle" class="help-button bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded fixed top-4 right-4">Aide</button>
 <div class="container mx-auto p-4">
 <?php if(!$code): ?>
     <h1>Planning Pharmacie</h1>
@@ -235,6 +236,17 @@ if ($new && !$code) {
     </a>
 </footer>
 <div id="toast" data-message="<?php echo htmlspecialchars($message); ?>" data-error="<?php echo htmlspecialchars($error); ?>"></div>
+<div id="helpOverlay" class="help-overlay"></div>
+<div id="helpSidebar" class="help-sidebar">
+    <button id="closeHelp" class="close-help">&times;</button>
+    <h2 class="text-xl font-semibold mb-4">Comment utiliser l'outil</h2>
+    <ol class="list-decimal list-inside space-y-2">
+        <li>Définir les noms et couleurs des pharmaciens.</li>
+        <li>Renseigner les horaires d'ouverture.</li>
+        <li>Ajouter le planning des pharmaciens.</li>
+        <li>Sauvegarder et noter le code du projet.</li>
+    </ol>
+</div>
 <script src="script.js?v=<?php echo filemtime('script.js'); ?>"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -266,3 +266,20 @@ if(document.getElementById('scheduleForm')){
     calculateHours();
 }
 
+const helpBtn = document.getElementById('helpToggle');
+if(helpBtn){
+    const sidebar = document.getElementById('helpSidebar');
+    const overlay = document.getElementById('helpOverlay');
+    const closeBtn = document.getElementById('closeHelp');
+    const closeHelp = ()=>{
+        sidebar.classList.remove('open');
+        overlay.classList.remove('show');
+    };
+    helpBtn.addEventListener('click',()=>{
+        sidebar.classList.add('open');
+        overlay.classList.add('show');
+    });
+    closeBtn.addEventListener('click', closeHelp);
+    overlay.addEventListener('click', closeHelp);
+}
+

--- a/style.css
+++ b/style.css
@@ -93,3 +93,55 @@ input[type="time"], select {
 }
 .toast.show {opacity:1;}
 .toast.error {background:#f44336;}
+
+.help-button {
+    z-index: 1002;
+}
+
+.help-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.3);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity .3s;
+    z-index: 1000;
+}
+
+.help-overlay.show {
+    opacity: 1;
+    visibility: visible;
+}
+
+.help-sidebar {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: 100%;
+    max-width: 320px;
+    background: #fff;
+    box-shadow: -2px 0 5px rgba(0,0,0,0.2);
+    transform: translateX(100%);
+    transition: transform .3s;
+    z-index: 1001;
+    padding: 20px;
+    overflow-y: auto;
+}
+
+.help-sidebar.open {
+    transform: translateX(0);
+}
+
+.close-help {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add help button opening a right-side help panel with step-by-step instructions
- style the help sidebar with responsive slide-in transition and overlay
- document the new integrated help and track its addition

## Testing
- `php -l index.php`
- `php -l print.php`
- `node --check script.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68af13ae45a8832086f254b93e214ebf