### PR TITLE
Add creator credit to footer

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -29,5 +29,5 @@ L'interface utilise Tailwind CSS et présente les différentes sections sous for
 - Un suivi de bugs séparé doit être maintenu pour chaque fonctionnalité.
 - Les fichiers CSS et JS sont chargés avec un paramètre de version basé sur leur date de modification afin d'éviter les problèmes de cache.
 - Les boutons « Ajouter tranche » sont stylisés dans un esprit Apple pour être plus visibles.
-- Le pied de page affiche « Fait avec ❤️ par Meditrust pour les pharmacies » avec le logo redirigeant vers la page de contact.
+- Le pied de page affiche « Fait avec ❤️ par Meditrust pour les pharmacies », accompagné du logo renvoyant vers la page de contact, et mentionne la création par @Yohan Azoulay (lien vers https://x.com/yazoulay).
 

--- a/index.php
+++ b/index.php
@@ -234,6 +234,8 @@ if ($new && !$code) {
     <a href="https://meditrust.io/contacter-nous/" target="_blank">
         <img src="https://meditrust.io/wp-content/uploads/2023/09/meditrust-logo-green.png" alt="Logo Meditrust" class="inline-block h-6 align-middle ml-2">
     </a>
+    <br>
+    Created By <a href="https://x.com/yazoulay" target="_blank">@Yohan Azoulay</a>
 </footer>
 <div id="toast" data-message="<?php echo htmlspecialchars($message); ?>" data-error="<?php echo htmlspecialchars($error); ?>"></div>
 <div id="helpOverlay" class="help-overlay"></div>


### PR DESCRIPTION
## Summary
- credit creator in site footer with link to Yohan Azoulay
- document footer credit addition

## Testing
- `php -l index.php`
- `php -l print.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1747978388320bf08cfec0a417eb1